### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/docs/tutorial/tutorial_authentication.php
+++ b/docs/tutorial/tutorial_authentication.php
@@ -17,7 +17,7 @@ if ( !$authentication->run() )
             );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 }

--- a/docs/tutorial/tutorial_group.php
+++ b/docs/tutorial/tutorial_group.php
@@ -32,7 +32,7 @@ if ( !$authentication->run() )
             );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 }

--- a/docs/tutorial/tutorial_htpasswd.php
+++ b/docs/tutorial/tutorial_htpasswd.php
@@ -18,7 +18,7 @@ if ( !$authentication->run() )
             );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 }

--- a/docs/tutorial/tutorial_ldap.php
+++ b/docs/tutorial/tutorial_ldap.php
@@ -18,7 +18,7 @@ if ( !$authentication->run() )
             );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 }

--- a/docs/tutorial/tutorial_multiple_credentials.php
+++ b/docs/tutorial/tutorial_multiple_credentials.php
@@ -37,7 +37,7 @@ if ( !$authentication->run() )
 
     foreach ( $status as $line => $error )
     {
-        list( $key, $value ) = each( $error );
+        $value = current( $error ); $key = key( $error );
         echo $err[$line][$key][$value] . "\n";
     }
 }

--- a/docs/tutorial/tutorial_openid_dumb.php
+++ b/docs/tutorial/tutorial_openid_dumb.php
@@ -39,7 +39,7 @@ if ( !$authentication->run() )
              );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 ?>

--- a/docs/tutorial/tutorial_openid_smart.php
+++ b/docs/tutorial/tutorial_openid_smart.php
@@ -46,7 +46,9 @@ if ( !$authentication->run() )
     $err["session"] = "";
     for ( $i = 0; $i < count( $status ); $i++ )
     {
-        list( $key, $value ) = each( $status[$i] );
+        $value = current( $status[$i] );
+        $key = key( $status[$i] );
+
         switch ( $key )
         {
             case 'ezcAuthenticationOpenidFilter':

--- a/docs/tutorial/tutorial_session.php
+++ b/docs/tutorial/tutorial_session.php
@@ -27,7 +27,7 @@ if ( !$authentication->run() )
             );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 }

--- a/docs/tutorial/tutorial_typekey.php
+++ b/docs/tutorial/tutorial_typekey.php
@@ -32,7 +32,7 @@ if ( !$authentication->run() )
              );
     foreach ( $status as $line )
     {
-        list( $key, $value ) = each( $line );
+        $value = current( $line ); $key = key( $line );
         echo $err[$key][$value] . "\n";
     }
 ?>

--- a/src/authentication.php
+++ b/src/authentication.php
@@ -58,7 +58,7 @@
  *             );
  *     foreach ( $status as $line )
  *     {
- *         list( $key, $value ) = each( $line );
+ *         $value = current( $line ); $key = key( $line );
  *         echo $err[$key][$value] . "\n";
  *     }
  * }
@@ -263,7 +263,8 @@ class ezcAuthentication
                     // status of the Authentication object
                     foreach ( $statuses as $status )
                     {
-                        list( $key, $value ) = each( $status );
+                        $value = current( $status );
+                        $key = key( $status );
                         $this->status->append( $key, $value );
                     }
                 }

--- a/src/filters/group/group_filter.php
+++ b/src/filters/group/group_filter.php
@@ -80,7 +80,7 @@
  *             );
  *     foreach ( $status as $line => $error )
  *     {
- *         list( $key, $value ) = each( $error );
+ *         $value = current( $error ); $key = key( $error );
  *         echo $err[$line][$key][$value] . "\n";
  *     }
  * }
@@ -133,7 +133,7 @@
  *
  *     foreach ( $status as $line => $error )
  *     {
- *         list( $key, $value ) = each( $error );
+ *         $value = current( $error ); $key = key( $error );
  *         echo $err[$line][$key][$value] . "\n";
  *     }
  * }

--- a/src/filters/htpasswd/htpasswd_filter.php
+++ b/src/filters/htpasswd/htpasswd_filter.php
@@ -60,7 +60,7 @@
  *             );
  *     foreach ( $status as $line )
  *     {
- *         list( $key, $value ) = each( $line );
+ *         $value = current( $line ); $key = key( $line );
  *         echo $err[$key][$value] . "\n";
  *     }
  * }

--- a/src/filters/ldap/ldap_filter.php
+++ b/src/filters/ldap/ldap_filter.php
@@ -52,7 +52,7 @@
  *             );
  *     foreach ( $status as $line )
  *     {
- *         list( $key, $value ) = each( $line );
+ *         $value = current( $line ); $key = key( $line );
  *         echo $err[$key][$value] . "\n";
  *     }
  * }

--- a/src/filters/openid/openid_filter.php
+++ b/src/filters/openid/openid_filter.php
@@ -148,7 +148,7 @@
  *              );
  *     foreach ( $status as $line )
  *     {
- *         list( $key, $value ) = each( $line );
+ *         $value = current( $line ); $key = key( $line );
  *         echo $err[$key][$value] . "\n";
  *     }
  * ?>

--- a/src/filters/typekey/typekey_filter.php
+++ b/src/filters/typekey/typekey_filter.php
@@ -117,7 +117,7 @@
  *              );
  *     foreach ( $status as $line )
  *     {
- *         list( $key, $value ) = each( $line );
+ *         $value = current( $line ); $key = key( $line );
  *         echo $err[$key][$value] . "\n";
  *     }
  * ?>

--- a/src/session/authentication_session.php
+++ b/src/session/authentication_session.php
@@ -68,7 +68,7 @@
  *             );
  *     foreach ( $status as $line )
  *     {
- *         list( $key, $value ) = each( $line );
+ *         $value = current( $line ); $key = key( $line );
  *         echo $err[$key][$value] . "\n";
  *     }
  * }


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.2 | /docs/tutorial/tutorial_authentication.php:20                                                      | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_group.php:35                                                               | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_htpasswd.php:21                                                            | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_ldap.php:21                                                                | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_multiple_credentials.php:40                                                | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_openid_dumb.php:42                                                         | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_openid_smart.php:49                                                        | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_session.php:30                                                             | function         | Function each() is deprecated. 
 7.2 | /docs/tutorial/tutorial_typekey.php:35                                                             | function         | Function each() is deprecated. 
 7.2 | /src/authentication.php:266                                                                        | function         | Function each() is deprecated. 
```